### PR TITLE
feat(api): switch item loading to Tarkov JSON endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,6 @@ NODE_ENV=""
 #posthog analytics
 NEXT_PUBLIC_POSTHOG_TOKEN=""
 NEXT_PUBLIC_POSTHOG_HOST="https://eu.i.posthog.com"
-#optional overrides for the Tarkov GraphQL endpoint
-NEXT_PUBLIC_TARKOV_GRAPHQL_URL="https://api.tarkov.dev/graphql"
-TARKOV_GRAPHQL_URL="https://api.tarkov.dev/graphql"
+#optional overrides for the Tarkov JSON endpoint
+NEXT_PUBLIC_TARKOV_JSON_URL="https://json.tarkov.dev"
+TARKOV_JSON_URL="https://json.tarkov.dev"

--- a/app/base-values/page.tsx
+++ b/app/base-values/page.tsx
@@ -9,7 +9,10 @@ import {
   useState,
   useTransition,
 } from "react";
-import { fetchMinimalTarkovData, MinimalItem } from "@/hooks/use-tarkov-api";
+import {
+  fetchMinimalTarkovDataForMode,
+  MinimalItem,
+} from "@/hooks/use-tarkov-api";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useFavorites } from "@/hooks/use-favorites";
 import { DEFAULT_EXCLUDED_ITEMS } from "@/config/excluded-items";
@@ -180,6 +183,33 @@ export default function ItemsTablePage() {
     []
   );
 
+  const applyModeFilters = useCallback((itemsForMode: MinimalItem[]) => {
+    setFilter((f) => ({
+      ...f,
+      basePrice: getMinMax(itemsForMode, "basePrice"),
+      lastLowPrice: getMinMax(itemsForMode, "lastLowPrice"),
+      avg24hPrice: getMinMax(itemsForMode, "avg24hPrice"),
+    }));
+  }, []);
+
+  const loadModeItems = useCallback(
+    async (targetMode: "pvp" | "pve", nextLanguage: string) => {
+      const apiMode = targetMode === "pve" ? "pve" : "regular";
+      const items = await fetchMinimalTarkovDataForMode(apiMode, nextLanguage);
+
+      setPvp((current) => (targetMode === "pvp" ? items : current));
+      setPve((current) => (targetMode === "pve" ? items : current));
+
+      return items;
+    },
+    []
+  );
+
+  const currentModeRef = useRef(mode);
+  useEffect(() => {
+    currentModeRef.current = mode;
+  }, [mode]);
+
   // Initialize favorites functionality
   const {
     isFavorite,
@@ -201,26 +231,24 @@ export default function ItemsTablePage() {
 
   useEffect(() => {
     let isMounted = true;
-    fetchMinimalTarkovData(language).then(
-      (data: { pvpItems: MinimalItem[]; pveItems: MinimalItem[] }) => {
-        if (isMounted) {
-          setPvp(data.pvpItems || []);
-          setPve(data.pveItems || []);
-          // Default to PVP min/max
-          setFilter((f) => ({
-            ...f,
-            basePrice: getMinMax(data.pvpItems || [], "basePrice"),
-            lastLowPrice: getMinMax(data.pvpItems || [], "lastLowPrice"),
-            avg24hPrice: getMinMax(data.pvpItems || [], "avg24hPrice"),
-          }));
-          setIsLoading(false);
-        }
-      }
-    );
+    setIsLoading(true);
+    setPvp([]);
+    setPve([]);
+
+    loadModeItems(currentModeRef.current, language)
+      .then((items) => {
+        if (!isMounted) return;
+        applyModeFilters(items);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setIsLoading(false);
+      });
     return () => {
       isMounted = false;
     };
-  }, [language]);
+  }, [applyModeFilters, language, loadModeItems]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -814,12 +842,19 @@ export default function ItemsTablePage() {
                       const newMode = "pvp";
                       setMode(newMode);
                       const newItems = pvp;
-                      setFilter((f) => ({
-                        ...f,
-                        basePrice: getMinMax(newItems, "basePrice"),
-                        lastLowPrice: getMinMax(newItems, "lastLowPrice"),
-                        avg24hPrice: getMinMax(newItems, "avg24hPrice"),
-                      }));
+                      if (newItems.length > 0) {
+                        applyModeFilters(newItems);
+                        return;
+                      }
+
+                      setIsLoading(true);
+                      loadModeItems(newMode, language)
+                        .then((items) => {
+                          applyModeFilters(items);
+                        })
+                        .finally(() => {
+                          setIsLoading(false);
+                        });
                     });
                   }}
                   className="h-8 px-3 rounded-full"
@@ -834,12 +869,19 @@ export default function ItemsTablePage() {
                       const newMode = "pve";
                       setMode(newMode);
                       const newItems = pve;
-                      setFilter((f) => ({
-                        ...f,
-                        basePrice: getMinMax(newItems, "basePrice"),
-                        lastLowPrice: getMinMax(newItems, "lastLowPrice"),
-                        avg24hPrice: getMinMax(newItems, "avg24hPrice"),
-                      }));
+                      if (newItems.length > 0) {
+                        applyModeFilters(newItems);
+                        return;
+                      }
+
+                      setIsLoading(true);
+                      loadModeItems(newMode, language)
+                        .then((items) => {
+                          applyModeFilters(items);
+                        })
+                        .finally(() => {
+                          setIsLoading(false);
+                        });
                     });
                   }}
                   className="h-8 px-3 rounded-full"

--- a/benchmark-results/benchmark-graphql-baseline.json
+++ b/benchmark-results/benchmark-graphql-baseline.json
@@ -1,0 +1,301 @@
+{
+  "capturedAt": "2026-04-08T19:10:48.895Z",
+  "baseUrl": "http://127.0.0.1:3101",
+  "coldRuns": 3,
+  "warmRuns": 3,
+  "settleDelayMs": 1500,
+  "results": [
+    {
+      "route": "/",
+      "coldRuns": [
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4.5,
+            "domContentLoadedMs": 155.29999999701977,
+            "loadEventMs": 530.7999999970198
+          },
+          "totalUntilSettledMs": 2322.0989999999997,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 619,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.399999998509884,
+            "domContentLoadedMs": 163.10000000149012,
+            "loadEventMs": 635.7999999970198
+          },
+          "totalUntilSettledMs": 2340.9044999999996,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 146,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4,
+            "domContentLoadedMs": 145.39999999850988,
+            "loadEventMs": 534.6999999955297
+          },
+          "totalUntilSettledMs": 2211.1432999999997,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 588,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.899999998509884,
+            "domContentLoadedMs": 146.79999999701977,
+            "loadEventMs": 460
+          },
+          "totalUntilSettledMs": 2185.8134999999993,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 611,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6.0999999940395355,
+            "domContentLoadedMs": 18.399999998509884,
+            "loadEventMs": 295.59999999403954
+          },
+          "totalUntilSettledMs": 1801.1476999999995,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 242,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3101/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.799999997019768,
+            "domContentLoadedMs": 18.599999994039536,
+            "loadEventMs": 323.59999999403954
+          },
+          "totalUntilSettledMs": 1834.1871999999985,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 378,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 3.9666666661699614,
+          "medianResponseStartMs": 4,
+          "avgDomContentLoadedMs": 154.5999999990066,
+          "medianDomContentLoadedMs": 155.29999999701977,
+          "avgLoadEventMs": 567.099999996523,
+          "medianLoadEventMs": 534.6999999955297,
+          "avgSettledMs": 2291.382266666666,
+          "medianSettledMs": 2322.0989999999997,
+          "avgRelevantRequestCount": 1,
+          "avgRelevantRequestDurationMs": 451
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 5.266666663189729,
+          "medianResponseStartMs": 5.799999997019768,
+          "avgDomContentLoadedMs": 61.26666666318973,
+          "medianDomContentLoadedMs": 18.599999994039536,
+          "avgLoadEventMs": 359.7333333293597,
+          "medianLoadEventMs": 323.59999999403954,
+          "avgSettledMs": 1940.3827999999992,
+          "medianSettledMs": 1834.1871999999985,
+          "avgRelevantRequestCount": 1,
+          "avgRelevantRequestDurationMs": 410.3333333333333
+        }
+      }
+    },
+    {
+      "route": "/base-values",
+      "coldRuns": [
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7.200000002980232,
+            "domContentLoadedMs": 16.5,
+            "loadEventMs": 493
+          },
+          "totalUntilSettledMs": 2009.5985,
+          "relevantRequests": []
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6.899999998509884,
+            "domContentLoadedMs": 15.799999997019768,
+            "loadEventMs": 592.6000000014901
+          },
+          "totalUntilSettledMs": 2106.0069999999996,
+          "relevantRequests": []
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6.399999998509884,
+            "domContentLoadedMs": 14,
+            "loadEventMs": 556.7999999970198
+          },
+          "totalUntilSettledMs": 2069.8485,
+          "relevantRequests": []
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7.100000001490116,
+            "domContentLoadedMs": 20.700000002980232,
+            "loadEventMs": 491.30000000447035
+          },
+          "totalUntilSettledMs": 1999.092700000001,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 760,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4.899999998509884,
+            "domContentLoadedMs": 16,
+            "loadEventMs": 260.29999999701977
+          },
+          "totalUntilSettledMs": 1767.803899999999,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 779,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3101/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.100000001490116,
+            "domContentLoadedMs": 16.200000002980232,
+            "loadEventMs": 323.5
+          },
+          "totalUntilSettledMs": 1829.6561000000002,
+          "relevantRequests": [
+            {
+              "url": "https://api.tarkov.dev/graphql",
+              "durationMs": 85,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 6.833333333333333,
+          "medianResponseStartMs": 6.899999998509884,
+          "avgDomContentLoadedMs": 15.433333332339922,
+          "medianDomContentLoadedMs": 15.799999997019768,
+          "avgLoadEventMs": 547.46666666617,
+          "medianLoadEventMs": 556.7999999970198,
+          "avgSettledMs": 2061.8179999999998,
+          "medianSettledMs": 2069.8485,
+          "avgRelevantRequestCount": 0,
+          "avgRelevantRequestDurationMs": 0
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 5.700000000496705,
+          "medianResponseStartMs": 5.100000001490116,
+          "avgDomContentLoadedMs": 17.633333335320156,
+          "medianDomContentLoadedMs": 16.200000002980232,
+          "avgLoadEventMs": 358.3666666671634,
+          "medianLoadEventMs": 323.5,
+          "avgSettledMs": 1865.5175666666667,
+          "medianSettledMs": 1829.6561000000002,
+          "avgRelevantRequestCount": 1,
+          "avgRelevantRequestDurationMs": 541.3333333333334
+        }
+      }
+    }
+  ]
+}

--- a/benchmark-results/benchmark-json-final.json
+++ b/benchmark-results/benchmark-json-final.json
@@ -1,0 +1,439 @@
+{
+  "capturedAt": "2026-04-08T19:18:28.978Z",
+  "baseUrl": "http://127.0.0.1:3103",
+  "coldRuns": 3,
+  "warmRuns": 3,
+  "settleDelayMs": 1500,
+  "results": [
+    {
+      "route": "/",
+      "coldRuns": [
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6.299999997019768,
+            "domContentLoadedMs": 177.5,
+            "loadEventMs": 601.1000000014901
+          },
+          "totalUntilSettledMs": 2429.7893,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 249,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 266,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 296,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.899999998509884,
+            "domContentLoadedMs": 172,
+            "loadEventMs": 1559.2000000029802
+          },
+          "totalUntilSettledMs": 3305.3394,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 9,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 66,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 80,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4.899999998509884,
+            "domContentLoadedMs": 170.80000000447035,
+            "loadEventMs": 694.7000000029802
+          },
+          "totalUntilSettledMs": 2451.0789999999997,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 8,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 42,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 71,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4.5,
+            "domContentLoadedMs": 168.30000000447035,
+            "loadEventMs": 737.8999999985099
+          },
+          "totalUntilSettledMs": 2489.4678999999996,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 9,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 46,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 80,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7.200000002980232,
+            "domContentLoadedMs": 24.700000002980232,
+            "loadEventMs": 662.7000000029802
+          },
+          "totalUntilSettledMs": 2171.7946999999986,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 16,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 16,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 16,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3103/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6.5,
+            "domContentLoadedMs": 20.399999998509884,
+            "loadEventMs": 609.5
+          },
+          "totalUntilSettledMs": 2127.0215000000007,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 15,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 15,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 15,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 5.033333331346512,
+          "medianResponseStartMs": 4.899999998509884,
+          "avgDomContentLoadedMs": 173.43333333482346,
+          "medianDomContentLoadedMs": 172,
+          "avgLoadEventMs": 951.6666666691502,
+          "medianLoadEventMs": 694.7000000029802,
+          "avgSettledMs": 2728.7358999999997,
+          "medianSettledMs": 2451.0789999999997,
+          "avgRelevantRequestCount": 3,
+          "avgRelevantRequestDurationMs": 362.3333333333333
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 6.066666667660077,
+          "medianResponseStartMs": 6.5,
+          "avgDomContentLoadedMs": 71.13333333532016,
+          "medianDomContentLoadedMs": 24.700000002980232,
+          "avgLoadEventMs": 670.03333333383,
+          "medianLoadEventMs": 662.7000000029802,
+          "avgSettledMs": 2262.761366666666,
+          "medianSettledMs": 2171.7946999999986,
+          "avgRelevantRequestCount": 3,
+          "avgRelevantRequestDurationMs": 76
+        }
+      }
+    },
+    {
+      "route": "/base-values",
+      "coldRuns": [
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7.600000001490116,
+            "domContentLoadedMs": 19.200000002980232,
+            "loadEventMs": 971.8999999985099
+          },
+          "totalUntilSettledMs": 2480.6095000000023,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 71,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 71,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 76,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7.399999998509884,
+            "domContentLoadedMs": 18.399999998509884,
+            "loadEventMs": 873.8000000044703
+          },
+          "totalUntilSettledMs": 2377.6299,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 55,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 56,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 65,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 6,
+            "domContentLoadedMs": 16.100000001490116,
+            "loadEventMs": 853.3999999985099
+          },
+          "totalUntilSettledMs": 2359.4300000000003,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 31,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 109,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 110,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.200000002980232,
+            "domContentLoadedMs": 16.399999998509884,
+            "loadEventMs": 978.1000000014901
+          },
+          "totalUntilSettledMs": 2488.1080999999976,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 70,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 90,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 90,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.600000001490116,
+            "domContentLoadedMs": 19.799999997019768,
+            "loadEventMs": 594
+          },
+          "totalUntilSettledMs": 2109.4868000000024,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 30,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 30,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 30,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3103/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.5999999940395355,
+            "domContentLoadedMs": 18.099999994039536,
+            "loadEventMs": 505
+          },
+          "totalUntilSettledMs": 2013.9812999999995,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 23,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 23,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/pve/items",
+              "durationMs": 23,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 7,
+          "medianResponseStartMs": 7.399999998509884,
+          "avgDomContentLoadedMs": 17.900000000993412,
+          "medianDomContentLoadedMs": 18.399999998509884,
+          "avgLoadEventMs": 899.7000000004967,
+          "medianLoadEventMs": 873.8000000044703,
+          "avgSettledMs": 2405.889800000001,
+          "medianSettledMs": 2377.6299,
+          "avgRelevantRequestCount": 3,
+          "avgRelevantRequestDurationMs": 214.66666666666666
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 5.466666666169961,
+          "medianResponseStartMs": 5.5999999940395355,
+          "avgDomContentLoadedMs": 18.099999996523064,
+          "medianDomContentLoadedMs": 18.099999994039536,
+          "avgLoadEventMs": 692.3666666671634,
+          "medianLoadEventMs": 594,
+          "avgSettledMs": 2203.858733333333,
+          "medianSettledMs": 2109.4868000000024,
+          "avgRelevantRequestCount": 3,
+          "avgRelevantRequestDurationMs": 136.33333333333334
+        }
+      }
+    }
+  ]
+}

--- a/benchmark-results/benchmark-json-perf-pass2.json
+++ b/benchmark-results/benchmark-json-perf-pass2.json
@@ -1,0 +1,379 @@
+{
+  "capturedAt": "2026-04-08T20:03:01.324Z",
+  "baseUrl": "http://127.0.0.1:3104",
+  "coldRuns": 3,
+  "warmRuns": 3,
+  "settleDelayMs": 1500,
+  "results": [
+    {
+      "route": "/",
+      "coldRuns": [
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.200000002980232,
+            "domContentLoadedMs": 160.20000000298023,
+            "loadEventMs": 451.6000000014901
+          },
+          "totalUntilSettledMs": 2208.6996,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 240,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 271,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.899999998509884,
+            "domContentLoadedMs": 139.80000000447035,
+            "loadEventMs": 470.3999999985099
+          },
+          "totalUntilSettledMs": 2180.6805,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 10,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 117,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.600000001490116,
+            "domContentLoadedMs": 148.10000000149012,
+            "loadEventMs": 614.9000000059605
+          },
+          "totalUntilSettledMs": 2321.6425,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 31,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 31,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 3.7999999970197678,
+            "domContentLoadedMs": 146.20000000298023,
+            "loadEventMs": 316.79999999701977
+          },
+          "totalUntilSettledMs": 2030.3641000000007,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 45,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 113,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.700000002980232,
+            "domContentLoadedMs": 18.600000001490116,
+            "loadEventMs": 356.30000000447035
+          },
+          "totalUntilSettledMs": 1865.9429,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 7,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 7,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3104/",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.700000002980232,
+            "domContentLoadedMs": 18.600000001490116,
+            "loadEventMs": 447.1000000014901
+          },
+          "totalUntilSettledMs": 1958.9063999999998,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 5,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 5,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 4.233333334326744,
+          "medianResponseStartMs": 3.899999998509884,
+          "avgDomContentLoadedMs": 149.3666666696469,
+          "medianDomContentLoadedMs": 148.10000000149012,
+          "avgLoadEventMs": 512.3000000019869,
+          "medianLoadEventMs": 470.3999999985099,
+          "avgSettledMs": 2237.0075333333334,
+          "medianSettledMs": 2208.6996,
+          "avgRelevantRequestCount": 2,
+          "avgRelevantRequestDurationMs": 233.33333333333334
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 5.066666667660077,
+          "medianResponseStartMs": 5.700000002980232,
+          "avgDomContentLoadedMs": 61.13333333532015,
+          "medianDomContentLoadedMs": 18.600000001490116,
+          "avgLoadEventMs": 373.40000000099343,
+          "medianLoadEventMs": 356.30000000447035,
+          "avgSettledMs": 1951.7378,
+          "medianSettledMs": 1958.9063999999998,
+          "avgRelevantRequestCount": 2,
+          "avgRelevantRequestDurationMs": 60.666666666666664
+        }
+      }
+    },
+    {
+      "route": "/base-values",
+      "coldRuns": [
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 8,
+            "domContentLoadedMs": 17.30000000447035,
+            "loadEventMs": 647.8000000044703
+          },
+          "totalUntilSettledMs": 2156.4948000000004,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 27,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 94,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7,
+            "domContentLoadedMs": 16.600000001490116,
+            "loadEventMs": 521.7999999970198
+          },
+          "totalUntilSettledMs": 2025.3557999999994,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 25,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 122,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "cold",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 7,
+            "domContentLoadedMs": 15.5,
+            "loadEventMs": 543.3000000044703
+          },
+          "totalUntilSettledMs": 2053.0836000000018,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 50,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 90,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "warmRuns": [
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 1,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.299999997019768,
+            "domContentLoadedMs": 14.299999997019768,
+            "loadEventMs": 670.6000000014901
+          },
+          "totalUntilSettledMs": 2174.4596999999994,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 25,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 25,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 2,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 4.699999995529652,
+            "domContentLoadedMs": 16.899999998509884,
+            "loadEventMs": 415.5
+          },
+          "totalUntilSettledMs": 1924.9000000000015,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 20,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 23,
+              "status": 200
+            }
+          ]
+        },
+        {
+          "route": "/base-values",
+          "mode": "warm",
+          "iteration": 3,
+          "url": "http://127.0.0.1:3104/base-values",
+          "status": 200,
+          "browserTimings": {
+            "responseStartMs": 5.5,
+            "domContentLoadedMs": 18.799999997019768,
+            "loadEventMs": 370.8999999985099
+          },
+          "totalUntilSettledMs": 1880.9580999999998,
+          "relevantRequests": [
+            {
+              "url": "https://json.tarkov.dev/regular/items",
+              "durationMs": 18,
+              "status": 200
+            },
+            {
+              "url": "https://json.tarkov.dev/regular/items_en",
+              "durationMs": 18,
+              "status": 200
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "cold": {
+          "count": 3,
+          "avgResponseStartMs": 7.333333333333333,
+          "medianResponseStartMs": 7,
+          "avgDomContentLoadedMs": 16.466666668653488,
+          "medianDomContentLoadedMs": 16.600000001490116,
+          "avgLoadEventMs": 570.9666666686535,
+          "medianLoadEventMs": 543.3000000044703,
+          "avgSettledMs": 2078.3114000000005,
+          "medianSettledMs": 2053.0836000000018,
+          "avgRelevantRequestCount": 2,
+          "avgRelevantRequestDurationMs": 136
+        },
+        "warm": {
+          "count": 3,
+          "avgResponseStartMs": 5.16666666418314,
+          "medianResponseStartMs": 5.299999997019768,
+          "avgDomContentLoadedMs": 16.66666666418314,
+          "medianDomContentLoadedMs": 16.899999998509884,
+          "avgLoadEventMs": 485.6666666666667,
+          "medianLoadEventMs": 415.5,
+          "avgSettledMs": 1993.439266666667,
+          "medianSettledMs": 1924.9000000000015,
+          "avgRelevantRequestCount": 2,
+          "avgRelevantRequestDurationMs": 43
+        }
+      }
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "eslint-config-prettier": "^10.0.1",
         "jsdom": "^26.1.0",
         "json5-loader": "^4.0.0",
+        "playwright": "^1.59.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.17",
         "typescript": "^5",
@@ -1094,7 +1095,7 @@
 
     "framer-motion": ["framer-motion@11.18.2", "", { "dependencies": { "motion-dom": "^11.18.1", "motion-utils": "^11.18.1", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid"] }, "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1558,6 +1559,10 @@
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -2008,6 +2013,8 @@
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -2064,6 +2071,8 @@
 
     "refractor/prismjs": ["prismjs@1.27.0", "", {}, "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
@@ -2087,6 +2096,8 @@
     "terser-webpack-plugin/schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": "lib/cli.js" }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite-node/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 

--- a/components/app.tsx
+++ b/components/app.tsx
@@ -73,6 +73,7 @@ import { type GitHubContributor } from "@/lib/github-contributors";
 import {
   getPersistedSelectedItemIds,
   parsePersistedSelectedItemIds,
+  remapSelectedItemsToCurrentData,
   restoreSelectedItemsFromIds,
   SELECTED_ITEM_IDS_STORAGE_KEY,
 } from "@/lib/persisted-selected-items";
@@ -472,6 +473,29 @@ function AppContent({ contributors = [] }: AppProps) {
 
     // Mark initialization complete
     didInitStateRef.current = true;
+  }, [rawItemsData]);
+
+  useEffect(() => {
+    if (!didInitStateRef.current) {
+      return;
+    }
+
+    if (!rawItemsData || rawItemsData.length === 0) {
+      return;
+    }
+
+    setSelectedItems((currentSelectedItems) => {
+      const remappedSelectedItems = remapSelectedItemsToCurrentData(
+        currentSelectedItems,
+        rawItemsData,
+      );
+
+      const hasChanged = remappedSelectedItems.some(
+        (item, index) => item !== currentSelectedItems[index],
+      );
+
+      return hasChanged ? remappedSelectedItems : currentSelectedItems;
+    });
   }, [rawItemsData]);
 
   // Auto-trigger notifications after onboarding completion and data load

--- a/docs/tarkov-json-api-research.md
+++ b/docs/tarkov-json-api-research.md
@@ -1,0 +1,160 @@
+# Tarkov JSON API Research
+
+Research run: 2026-04-08
+
+## Current repo usage
+
+The current live API surface in this repo is narrower than the full `json.tarkov.dev` endpoint list.
+
+- Runtime item loading is centered in `hooks/use-tarkov-api.ts`.
+- UI consumption is mainly `hooks/use-items-data.ts`, `components/app.tsx`, `components/item-selector.tsx`, and `app/base-values/page.tsx`.
+- Secondary CLI/script consumers are `scripts/generate-recipe-icons.ts`, `tools/lookup-item.ts`, and `tools/add-recipe.ts`.
+
+From that usage, the current repo only needs item data plus translations to replace the GraphQL fetchers.
+
+## Endpoints we actually need now
+
+Required for runtime parity:
+
+- `/regular/items`
+- `/pve/items`
+- `/regular/items_en`
+- `/regular/items_{lang}` when localized item names are requested
+
+Optional:
+
+- `/lang` if we want the UI to discover available languages from the API instead of keeping a local language list
+
+Not currently used by this repo:
+
+- `/regular/maps`
+- `/regular/tasks`
+- `/regular/hideout`
+- `/regular/crafts`
+- `/regular/barters`
+- `/regular/traders`
+- `/status`
+- `/regular/prices/{itemId}`
+
+## Confirmed shape differences vs current GraphQL code
+
+### `items` is not a flat array
+
+`/regular/items` returns:
+
+- `data.items` as an object keyed by item id
+- `data.itemCategories` as a second dictionary keyed by category id
+- `data.handbookCategories` as another dictionary keyed by handbook id
+
+The current GraphQL code expects an `items[]` array. A migration needs a flattening step with `Object.values(data.items)`.
+
+### Base item strings are translation keys, not final display strings
+
+The base endpoint returns placeholder-ish translation keys such as:
+
+- item `name`
+- item `shortName`
+- category `name`
+- trader `name`
+
+Those are resolved by separate translation endpoints like `/regular/items_en` and `/regular/items_fr`.
+
+### Trader offers use different field names
+
+The JSON `items` endpoint exposes:
+
+- `buyFromTrader`
+- `sellToTrader`
+
+The current app expects:
+
+- `buyFor`
+- `sellFor`
+
+That mapping is straightforward, but the nested trader reference is an id string instead of an inline vendor object. To rebuild `normalizedName`, a local trader lookup is needed or we can rely on the static trader-name mapping already used in the UI.
+
+### Categories come through as ids
+
+The JSON item shape uses:
+
+- `categories: string[]`
+
+The current app already prefers stable category ids for filtering, so this is actually helpful. We still need a lookup step to rebuild the current `categories_display` shape for the UI.
+
+## Confirmed parity gap
+
+The current GraphQL implementation exposes `buyLimit` on direct trader offers inside `buyFor.vendor`.
+
+Live JSON findings from `2026-04-08`:
+
+- `items[*].buyFromTrader[*]` does not expose `buyLimit`
+- `traders` does not expose `buyLimit`
+- `barters` does expose `buyLimit`, but that only covers barter offers, not all direct trader buys
+
+That means the current base-values table cannot be migrated with full parity using only the JSON `items` endpoint. The `buyLimit` column/export behavior needs one of these decisions:
+
+1. Accept a temporary regression for direct trader buy limits.
+2. Supplement with another upstream source if one becomes available.
+3. Change the UI so `buyLimit` is only shown when the API actually provides it.
+
+This is the main blocker I found.
+
+## Recommended migration shape
+
+For this repo, the lowest-risk approach is a repo-specific adapter rather than a generic GraphQL emulation layer.
+
+Implemented adapter responsibilities:
+
+- fetch `/{mode}/items`
+- fetch `/regular/items_en`
+- fetch `/regular/items_{lang}` when `lang !== en`
+- flatten `data.items`
+- translate `name`, `shortName`, and category names with the translation maps
+- map `buyFromTrader -> buyFor`
+- map `sellToTrader -> sellFor`
+- rebuild `categories_display` from `itemCategories`
+- preserve `buyLimit` as optional because direct trader offers do not provide it in the JSON item payload
+
+That is enough to replace the existing item fetchers used by the current app and scripts.
+
+## Benchmark note
+
+The production benchmark harness lives in `scripts/benchmark-load.mjs`.
+
+Measured on 2026-04-08 with a 1500 ms post-load settle window:
+
+- GraphQL baseline artifact: `benchmark-results/benchmark-graphql-baseline.json`
+- JSON final artifact: `benchmark-results/benchmark-json-final.json`
+- JSON performance pass 2 artifact: `benchmark-results/benchmark-json-perf-pass2.json`
+
+The second performance pass kept everything client-side and improved the first JSON implementation by:
+
+- switching the main app route to one mode-specific fetch instead of a combined dual-mode fetch
+- reusing shared translation requests across concurrent mode fetches
+- loading only the active mode on `/base-values` and deferring the other mode until the user switches
+
+That dropped the initial request count:
+
+- `/`: `3 -> 2`
+- `/base-values`: `3 -> 2`
+
+In this harness, the second pass recovered most of the lost performance:
+
+- `/` average settled time: GraphQL `2291 ms`, first JSON `2729 ms`, performance pass 2 `2237 ms`
+- `/base-values` average settled time: GraphQL `2062 ms`, first JSON `2406 ms`, performance pass 2 `2078 ms`
+
+The JSON path is now much closer to the GraphQL baseline without adding any server-side work, but warm loads are still slower than GraphQL.
+
+## Probe command
+
+Use the live probe to refresh this research:
+
+```bash
+bun run probe:json-api
+```
+
+You can pass a non-English language code as the first argument:
+
+```bash
+bun run probe:json-api de
+```

--- a/hooks/use-items-data.ts
+++ b/hooks/use-items-data.ts
@@ -113,36 +113,9 @@ export function useItemsData(isPVE: boolean) {
       try {
       console.debug(`🔍 Fetching items [${mode}] language=${language} at ${new Date().toLocaleTimeString()}`);
 
-      // Always fetch English for filtering
-      const english = await fetchTarkovData(gameMode as 'pve' | 'regular', 'en');
-      // If EN, do not fetch localized; use English for display/filters
-      if (language === 'en') {
-        const mapped: SimplifiedItem[] = english.items.map((en) => ({
-          ...en,
-          categories: en.categories,
-          categories_display: en.categories_display,
-          categories_display_en: en.categories_display,
-          englishName: en.name,
-          englishShortName: en.shortName,
-          name: en.name,
-          shortName: en.shortName,
-          iconLink: en.iconLink,
-        } as SimplifiedItem));
-        // Store
-        if (isPVE) {
-          requestTracker.lastDataPVE = mapped;
-          requestTracker.lastLangPVE = 'en';
-        } else {
-          requestTracker.lastDataPVP = mapped;
-          requestTracker.lastLangPVP = 'en';
-        }
-        return mapped;
-      }
-      // Fetch localized only when lang !== 'en'
-      const localized = await fetchTarkovData(gameMode as 'pve' | 'regular', language);
+      const response = await fetchTarkovData(gameMode as 'pve' | 'regular', language);
 
-      // Use English count to determine emptiness
-      if (english.items.length === 0) {
+      if (response.items.length === 0) {
         console.warn(`⚠️ [${mode.toUpperCase()}] Received empty data from API`);
         
         // Increment retry count
@@ -164,39 +137,26 @@ export function useItemsData(isPVE: boolean) {
       requestTracker.retryCount = 0;
       if (isMounted.current) setNeedsManualRetry(false);
 
-      // Merge English with localized by id
-      const localizedById = new Map(localized.items.map((it) => [it.id, it] as const));
-      const merged: SimplifiedItem[] = english.items.map((en) => {
-        const loc = localizedById.get(en.id);
-        return {
-          ...en,
-          // keep English categories for filtering logic
-          categories: en.categories,
-          // display localized categories if available
-          categories_display: loc?.categories_display ?? en.categories_display,
-          // always keep english categories for stable filtering by ID mapping
-          categories_display_en: en.categories_display,
-          // capture English names for filtering
-          englishName: en.name,
-          englishShortName: en.shortName,
-          // display localized names when available
-          name: loc?.name ?? en.name,
-          shortName: loc?.shortName ?? en.shortName,
-          // icon: prefer localized when available for non-EN
-          iconLink: loc?.iconLink ?? en.iconLink,
-        } as SimplifiedItem;
-      });
+      const mapped: SimplifiedItem[] = response.items.map((item) => ({
+        ...item,
+        categories: item.categories,
+        categories_display: item.categories_display,
+        categories_display_en:
+          item.categories_display_en ?? item.categories_display,
+        englishName: item.englishName ?? item.name,
+        englishShortName: item.englishShortName ?? item.shortName,
+      } as SimplifiedItem));
 
       // Store the data in the appropriate cache
       if (isPVE) {
-        requestTracker.lastDataPVE = merged;
+        requestTracker.lastDataPVE = mapped;
         requestTracker.lastLangPVE = language;
       } else {
-        requestTracker.lastDataPVP = merged;
+        requestTracker.lastDataPVP = mapped;
         requestTracker.lastLangPVP = language;
       }
 
-      return merged;
+      return mapped;
     } catch (error) {
       console.error(`❌ [${mode.toUpperCase()}] Fetch error:`, error);
       

--- a/hooks/use-tarkov-api.ts
+++ b/hooks/use-tarkov-api.ts
@@ -1,14 +1,32 @@
 import type { SimplifiedItem } from "@/types/SimplifiedItem";
-import type { GraphQLResponse, TarkovItem } from "@/types/GraphQLResponse";
 
-const DEFAULT_GRAPHQL_API_URL = "https://api.tarkov.dev/graphql";
+const DEFAULT_JSON_API_URL = "https://json.tarkov.dev";
 
-const GRAPHQL_API_URL =
+const JSON_API_URL =
   typeof window !== "undefined"
-    ? process.env.NEXT_PUBLIC_TARKOV_GRAPHQL_URL ?? DEFAULT_GRAPHQL_API_URL
-    : process.env.TARKOV_GRAPHQL_URL ?? DEFAULT_GRAPHQL_API_URL;
+    ? process.env.NEXT_PUBLIC_TARKOV_JSON_URL ?? DEFAULT_JSON_API_URL
+    : process.env.TARKOV_JSON_URL ?? DEFAULT_JSON_API_URL;
 
-// Define a type for the combined data response
+const TRADER_NAME_BY_ID: Record<string, string> = {
+  "54cb50c76803fa8b248b4571": "prapor",
+  "54cb57776803fa99248b456e": "therapist",
+  "579dc571d53a0658a154fbec": "fence",
+  "58330581ace78e27b8b10cee": "skier",
+  "5935c25fb3acc3127c3d8cd9": "peacekeeper",
+  "5a7c2eca46aef81a7ca2145d": "mechanic",
+  "5ac3b934156ae10c4430e83c": "ragman",
+  "5c0647fdd443bc2504c2d371": "jaeger",
+  "638f541a29ffd1183d187f57": "lightkeeper",
+  "656f0f98d80a697f855d34b1": "btr-driver",
+  "68fe15990f29ba3fdbba9d55": "radio-station",
+  "68fe15910f29ba3fdbba9d54": "taran",
+  "6617beeaa9cfa777ca915b7c": "ref",
+  "688246518448b05efd61d461": "mr-kerman",
+  "688246958448b05efd61d462": "voevoda",
+};
+
+type GameMode = "regular" | "pve";
+
 interface CombinedTarkovData {
   pvp: SimplifiedItem[];
   pve: SimplifiedItem[];
@@ -20,213 +38,400 @@ interface CombinedTarkovData {
   };
 }
 
-// Define a consistent cache TTL to use across the application
+interface JsonItemCategory {
+  id: string;
+  name: string;
+  normalizedName: string;
+  parent: string | null;
+  children: string[];
+}
+
+interface JsonTraderOffer {
+  trader: string;
+  price: number;
+  priceRUB: number;
+  currency: string;
+  currencyItem: string;
+  minTraderLevel?: number;
+  buyLimit?: number;
+  taskUnlock?: string | null;
+}
+
+interface JsonItem {
+  id: string;
+  name: string;
+  shortName: string;
+  normalizedName: string;
+  description: string;
+  updated: string;
+  width: number;
+  height: number;
+  lastOfferCount?: number | null;
+  iconLink: string;
+  link: string;
+  basePrice: number;
+  lastLowPrice: number | null;
+  avg24hPrice: number | null;
+  categories: string[];
+  buyFromTrader?: JsonTraderOffer[];
+  sellToTrader?: JsonTraderOffer[];
+}
+
+interface JsonItemsResponse {
+  data: {
+    items: Record<string, JsonItem>;
+    itemCategories: Record<string, JsonItemCategory>;
+  };
+}
+
+interface JsonTranslationResponse {
+  data: Record<string, string>;
+}
+
+interface TranslationMaps {
+  primary: Record<string, string>;
+  fallback: Record<string, string>;
+}
+
+interface ModePayload {
+  items: JsonItem[];
+  itemCategories: Record<string, JsonItemCategory>;
+}
+
 export const CACHE_TTL = 900000; // 15 minutes
 
-// Cache for the combined data to avoid duplicate fetches (per language)
-const combinedDataCacheByLang: Map<
+const combinedDataCacheByLang = new Map<
   string,
   { data: CombinedTarkovData; time: number }
-> = new Map();
+>();
 
-// Cache for the minimal data to avoid duplicate fetches (per language)
-const minimalDataCacheByLang: Map<
+const modeDataCacheByModeAndLang = new Map<
+  string,
+  {
+    data: {
+      items: SimplifiedItem[];
+      meta: {
+        totalItems: number;
+        validItems: number;
+        processTime: number;
+        categories: number;
+        mode: string;
+      };
+    };
+    time: number;
+  }
+>();
+
+const minimalModeDataCacheByModeAndLang = new Map<
+  string,
+  { data: MinimalItem[]; time: number }
+>();
+
+const minimalDataCacheByLang = new Map<
   string,
   { data: { pvpItems: MinimalItem[]; pveItems: MinimalItem[] }; time: number }
-> = new Map();
+>();
+
+const rawModePayloadCacheByMode = new Map<
+  GameMode,
+  { data: ModePayload; time: number }
+>();
+
+const translationCacheByLang = new Map<
+  string,
+  { data: TranslationMaps; time: number }
+>();
+const inFlightTranslationRequests = new Map<string, Promise<TranslationMaps>>();
 
 export function resetTarkovApiCachesForTests() {
   combinedDataCacheByLang.clear();
+  modeDataCacheByModeAndLang.clear();
+  minimalModeDataCacheByModeAndLang.clear();
   minimalDataCacheByLang.clear();
+  rawModePayloadCacheByMode.clear();
+  translationCacheByLang.clear();
+  inFlightTranslationRequests.clear();
 }
 
-/**
- * Fetches all Tarkov item data from the tarkov.dev GraphQL API for both game modes
- * @returns Promise with combined data for both PVP and PVE modes
- */
+function normalizeLanguage(language: string) {
+  return language.toLowerCase();
+}
+
+function modeCacheKey(gameMode: GameMode, language: string) {
+  return `${gameMode}:${normalizeLanguage(language)}`;
+}
+
+async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${JSON_API_URL}${path}`, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new Error(`RATE_LIMIT:${response.status}`);
+    }
+
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+function translateValue(
+  key: string | undefined,
+  primary: Record<string, string>,
+  fallback: Record<string, string>
+): string | undefined {
+  if (!key) {
+    return undefined;
+  }
+
+  return primary[key] ?? fallback[key] ?? key;
+}
+
+function getCategoryDisplay(
+  categoryIds: string[],
+  itemCategories: Record<string, JsonItemCategory>,
+  translations: TranslationMaps,
+  useFallbackOnly: boolean = false
+) {
+  return categoryIds.map((categoryId) => ({
+    id: categoryId,
+    name:
+      translateValue(
+        itemCategories[categoryId]?.name,
+        useFallbackOnly ? translations.fallback : translations.primary,
+        translations.fallback
+      ) ?? categoryId,
+  }));
+}
+
+function mapBuyOffers(offers?: JsonTraderOffer[]) {
+  if (!offers || offers.length === 0) {
+    return undefined;
+  }
+
+  const mapped = offers
+    .filter((offer) => typeof offer?.priceRUB === "number")
+    .map((offer) => ({
+      priceRUB: offer.priceRUB,
+      vendor: {
+        normalizedName: TRADER_NAME_BY_ID[offer.trader] ?? offer.trader,
+        minTraderLevel: offer.minTraderLevel,
+        buyLimit: offer.buyLimit,
+      },
+    }));
+
+  return mapped.length > 0 ? mapped : undefined;
+}
+
+function mapSellOffers(offers?: JsonTraderOffer[]) {
+  if (!offers || offers.length === 0) {
+    return undefined;
+  }
+
+  const mapped = offers
+    .filter((offer) => typeof offer?.priceRUB === "number")
+    .map((offer) => ({
+      priceRUB: offer.priceRUB,
+      vendor: {
+        normalizedName: TRADER_NAME_BY_ID[offer.trader] ?? offer.trader,
+      },
+    }));
+
+  return mapped.length > 0 ? mapped : undefined;
+}
+
+async function fetchItemTranslations(language: string): Promise<TranslationMaps> {
+  const normalizedLanguage = normalizeLanguage(language);
+  const cached = translationCacheByLang.get(normalizedLanguage);
+  const now = Date.now();
+
+  if (cached && now - cached.time < CACHE_TTL) {
+    return cached.data;
+  }
+
+  const inFlight = inFlightTranslationRequests.get(normalizedLanguage);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const request = (async () => {
+    const [fallbackTranslations, primaryTranslations] = await Promise.all([
+      fetchJson<JsonTranslationResponse>("/regular/items_en"),
+      normalizedLanguage === "en"
+        ? Promise.resolve<JsonTranslationResponse>({ data: {} })
+        : fetchJson<JsonTranslationResponse>(
+            `/regular/items_${normalizedLanguage}`
+          ),
+    ]);
+
+    const translations: TranslationMaps = {
+      primary:
+        normalizedLanguage === "en"
+          ? fallbackTranslations.data
+          : primaryTranslations.data,
+      fallback: fallbackTranslations.data,
+    };
+
+    translationCacheByLang.set(normalizedLanguage, {
+      data: translations,
+      time: Date.now(),
+    });
+    return translations;
+  })();
+
+  inFlightTranslationRequests.set(normalizedLanguage, request);
+  try {
+    return await request;
+  } finally {
+    inFlightTranslationRequests.delete(normalizedLanguage);
+  }
+}
+
+async function fetchModePayload(gameMode: GameMode): Promise<ModePayload> {
+  const cached = rawModePayloadCacheByMode.get(gameMode);
+  const now = Date.now();
+
+  if (cached && now - cached.time < CACHE_TTL) {
+    return cached.data;
+  }
+
+  const itemsResponse = await fetchJson<JsonItemsResponse>(`/${gameMode}/items`);
+  const payload: ModePayload = {
+    items: Object.values(itemsResponse.data.items),
+    itemCategories: itemsResponse.data.itemCategories,
+  };
+
+  rawModePayloadCacheByMode.set(gameMode, { data: payload, time: now });
+  return payload;
+}
+
+function transformCombinedItem(
+  item: JsonItem,
+  payload: ModePayload,
+  translations: TranslationMaps
+): SimplifiedItem {
+  const englishName =
+    translateValue(item.name, translations.fallback, translations.fallback) ??
+    item.name;
+  const englishShortName =
+    translateValue(
+      item.shortName,
+      translations.fallback,
+      translations.fallback
+    ) ?? item.shortName;
+
+  return {
+    id: item.id,
+    name:
+      translateValue(item.name, translations.primary, translations.fallback) ??
+      item.name,
+    shortName:
+      translateValue(
+        item.shortName,
+        translations.primary,
+        translations.fallback
+      ) ?? item.shortName,
+    englishName,
+    englishShortName,
+    basePrice: item.basePrice,
+    lastLowPrice: item.lastLowPrice ?? undefined,
+    updated: item.updated,
+    lastOfferCount: item.lastOfferCount ?? undefined,
+    avg24hPrice: item.avg24hPrice ?? undefined,
+    iconLink: item.iconLink,
+    link: item.link,
+    width: item.width,
+    height: item.height,
+    categories: item.categories,
+    tags: [],
+    isExcluded: false,
+    categories_display: getCategoryDisplay(
+      item.categories,
+      payload.itemCategories,
+      translations
+    ),
+    categories_display_en: getCategoryDisplay(
+      item.categories,
+      payload.itemCategories,
+      translations,
+      true
+    ),
+    buyFor: mapBuyOffers(item.buyFromTrader),
+  };
+}
+
+function transformMinimalItem(
+  item: JsonItem,
+  payload: ModePayload,
+  translations: TranslationMaps
+): MinimalItem {
+  return {
+    id: item.id,
+    name:
+      translateValue(item.name, translations.primary, translations.fallback) ??
+      item.name,
+    shortName:
+      translateValue(
+        item.shortName,
+        translations.primary,
+        translations.fallback
+      ) ?? item.shortName,
+    basePrice: item.basePrice,
+    lastLowPrice: item.lastLowPrice,
+    avg24hPrice: item.avg24hPrice,
+    categories: getCategoryDisplay(
+      item.categories,
+      payload.itemCategories,
+      translations
+    ).map((category) => ({
+      name: category.name,
+    })),
+    link: item.link,
+    sellFor: mapSellOffers(item.sellToTrader) ?? [],
+    buyFor: mapBuyOffers(item.buyFromTrader) ?? [],
+  };
+}
+
 export async function fetchCombinedTarkovData(
   language: string = "en"
 ): Promise<CombinedTarkovData> {
+  const normalizedLanguage = normalizeLanguage(language);
   const now = Date.now();
+  const cached = combinedDataCacheByLang.get(normalizedLanguage);
 
-  // Return cached data if it's still fresh
-  const cached = combinedDataCacheByLang.get(language);
   if (cached && now - cached.time < CACHE_TTL) {
-    console.debug(`📦 Using cached combined Tarkov data [${language}]`);
+    console.debug(`📦 Using cached combined Tarkov data [${normalizedLanguage}]`);
     return cached.data;
   }
 
   const startTime = Date.now();
 
-  // Query both game modes in a single request
-  const query = `
-    {
-      pvpItems: items(gameMode: regular, lang: ${language}) {
-        id
-        name
-        shortName
-        basePrice
-        lastLowPrice
-        updated
-        width
-        height
-        lastOfferCount
-        iconLink
-        avg24hPrice
-        link
-        categories {
-          id
-          name
-        }
-        buyFor {
-          priceRUB
-          vendor {
-            normalizedName
-            ... on TraderOffer {
-              minTraderLevel
-            }
-          }
-        }
-      }
-      pveItems: items(gameMode: pve, lang: ${language}) {
-        id
-        name
-        shortName
-        basePrice
-        lastLowPrice
-        updated
-        width
-        height
-        lastOfferCount
-        avg24hPrice
-        iconLink
-        link
-        categories {
-          id
-          name
-        }
-        buyFor {
-          priceRUB
-          vendor {
-            normalizedName
-            ... on TraderOffer {
-              minTraderLevel
-            }
-          }
-        }
-      }
-    }
-  `;
-
   try {
-    console.debug("🔄 Fetching combined Tarkov data");
-    const response = await fetch(GRAPHQL_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ query }),
-    });
+    const [pvpData, pveData] = await Promise.all([
+      fetchTarkovData("regular", normalizedLanguage),
+      fetchTarkovData("pve", normalizedLanguage),
+    ]);
 
-    if (!response.ok) {
-      if (response.status === 429) {
-        throw new Error(`RATE_LIMIT:${response.status}`);
-      }
-      throw new Error(`API request failed with status ${response.status}`);
-    }
-
-    const { data, errors } = (await response.json()) as GraphQLResponse;
-
-    // Check if we have valid data first
-    if (!data?.pvpItems || !data?.pveItems) {
-      throw new Error("Missing data in API response");
-    }
-
-    // Only throw on errors if they're critical (not just translation warnings)
-    if (errors && errors.length > 0) {
-      // Check if all errors are translation-related (non-critical)
-      const hasNonTranslationErrors = errors.some(
-        (e) => !e.message.includes("Missing translation for key")
-      );
-
-      if (hasNonTranslationErrors) {
-        console.error("GraphQL errors:", errors);
-        throw new Error(
-          `GraphQL errors: ${errors.map((e) => e.message).join(", ")}`
-        );
-      } else {
-        // Just log translation warnings, don't fail the request
-        console.warn(
-          `⚠️ Translation warnings (${errors.length} items missing translations for language: ${language})`
-        );
-      }
-    }
-
-    // Transform the data for both modes
-    const transformItem = (item: TarkovItem) => ({
-      id: item.id,
-      name: item.name,
-      shortName: item.shortName,
-      basePrice: item.basePrice,
-      lastLowPrice: item.lastLowPrice || undefined,
-      updated: item.updated,
-      lastOfferCount: item.lastOfferCount || undefined,
-      avg24hPrice: item.avg24hPrice || undefined,
-      iconLink: item.iconLink,
-      link: item.link,
-      width: item.width,
-      height: item.height,
-      // Use language-agnostic category IDs for filtering logic
-      // Non-null assertion is safe here because this query selects `id` for categories
-      categories: item.categories.map(
-        (cat: { id?: string; name: string }) => cat.id!
-      ),
-      tags: [],
-      isExcluded: false,
-      categories_display: item.categories,
-      buyFor: item.buyFor
-        ? item.buyFor
-          .filter((o) => !!o && !!o.vendor && typeof o.priceRUB === "number")
-          .map((o) => ({
-            priceRUB: o.priceRUB,
-            vendor: {
-              normalizedName: o.vendor.normalizedName,
-              minTraderLevel: o.vendor.minTraderLevel,
-            },
-          }))
-        : undefined,
-    });
-
-    const transformPvpItems = data.pvpItems.map(transformItem);
-    const transformPveItems = data.pveItems.map(transformItem);
-
-    // buyFor is already included in the combined query above; no merge needed.
-
-    // Count unique categories (combining both modes)
     const allCategories = new Set(
-      [...transformPvpItems, ...transformPveItems].flatMap(
-        (item) => item.categories || []
-      )
+      [...pvpData.items, ...pveData.items].flatMap((item) => item.categories || [])
     );
 
-    const processTime = Date.now() - startTime;
-
-    // Update the cache
     const combined: CombinedTarkovData = {
-      pvp: transformPvpItems,
-      pve: transformPveItems,
+      pvp: pvpData.items,
+      pve: pveData.items,
       meta: {
-        totalItems: transformPvpItems.length + transformPveItems.length,
-        validItems: transformPvpItems.length + transformPveItems.length,
-        processTime,
+        totalItems: pvpData.items.length + pveData.items.length,
+        validItems: pvpData.items.length + pveData.items.length,
+        processTime: Date.now() - startTime,
         categories: allCategories.size,
       },
     };
-    // store per-language cache
-    combinedDataCacheByLang.set(language, { data: combined, time: now });
 
-    // Data has been fetched and processed successfully
-
+    combinedDataCacheByLang.set(normalizedLanguage, { data: combined, time: now });
     return combined;
   } catch (error) {
     console.error("Error fetching combined Tarkov data:", error);
@@ -234,11 +439,6 @@ export async function fetchCombinedTarkovData(
   }
 }
 
-/**
- * Fetches Tarkov item data for a specific game mode
- * @param gameMode 'pve' or 'regular' (pvp)
- * @returns Promise with transformed items in SimplifiedItem format
- */
 export async function fetchTarkovData(
   gameMode: "pve" | "regular",
   language: string = "en"
@@ -252,29 +452,41 @@ export async function fetchTarkovData(
     mode: string;
   };
 }> {
+  const normalizedLanguage = normalizeLanguage(language);
+  const cacheKey = modeCacheKey(gameMode, normalizedLanguage);
+  const now = Date.now();
+  const cached = modeDataCacheByModeAndLang.get(cacheKey);
+
+  if (cached && now - cached.time < CACHE_TTL) {
+    return cached.data;
+  }
+
+  const startTime = Date.now();
+
   try {
-    // Use the combined data fetcher and extract the relevant mode's data
-    const combinedData = await fetchCombinedTarkovData(language);
+    const [payload, translations] = await Promise.all([
+      fetchModePayload(gameMode),
+      fetchItemTranslations(normalizedLanguage),
+    ]);
 
-    // Extract the items for the requested game mode
-    const items = gameMode === "pve" ? combinedData.pve : combinedData.pvp;
-
-    // Count categories for this specific mode
-    const categoryCount = new Set(
-      items.flatMap((item) => item.categories || [])
+    const items = payload.items.map((item) =>
+      transformCombinedItem(item, payload, translations)
     );
+    const categoryCount = new Set(items.flatMap((item) => item.categories || []));
 
-    // Return the data in the expected format
-    return {
+    const data = {
       items,
       meta: {
-        ...combinedData.meta,
         totalItems: items.length,
         validItems: items.length,
+        processTime: Date.now() - startTime,
         categories: categoryCount.size,
         mode: gameMode === "pve" ? "pve" : "pvp",
       },
     };
+
+    modeDataCacheByModeAndLang.set(cacheKey, { data, time: now });
+    return data;
   } catch (error) {
     console.error(`Error fetching Tarkov data (${gameMode}):`, error);
     throw error;
@@ -308,145 +520,64 @@ export interface MinimalItem {
   }[];
 }
 
-interface FetchMinimalTarkovGraphQLResponse {
-  data?: {
-    pvpItems: MinimalItem[];
-    pveItems: MinimalItem[];
-  };
-  errors?: Array<{ message: string }>;
+export async function fetchMinimalTarkovDataForMode(
+  gameMode: "pve" | "regular",
+  language: string = "en"
+): Promise<MinimalItem[]> {
+  const normalizedLanguage = normalizeLanguage(language);
+  const cacheKey = modeCacheKey(gameMode, normalizedLanguage);
+  const now = Date.now();
+  const cached = minimalModeDataCacheByModeAndLang.get(cacheKey);
+
+  if (cached && now - cached.time < CACHE_TTL) {
+    console.debug(
+      `📦 Using cached minimal Tarkov data [${gameMode}:${normalizedLanguage}]`
+    );
+    return cached.data;
+  }
+
+  const startTime = Date.now();
+
+  try {
+    const [payload, translations] = await Promise.all([
+      fetchModePayload(gameMode),
+      fetchItemTranslations(normalizedLanguage),
+    ]);
+
+    const items = payload.items.map((item) =>
+      transformMinimalItem(item, payload, translations)
+    );
+
+    console.debug(
+      `✅ Minimal Tarkov data fetched in ${Date.now() - startTime}ms for ${gameMode}`
+    );
+
+    minimalModeDataCacheByModeAndLang.set(cacheKey, { data: items, time: now });
+    return items;
+  } catch (error) {
+    console.error(`❌ Failed to fetch minimal Tarkov data (${gameMode}):`, error);
+    return [];
+  }
 }
 
 export async function fetchMinimalTarkovData(
   language: string = "en"
 ): Promise<{ pvpItems: MinimalItem[]; pveItems: MinimalItem[] }> {
+  const normalizedLanguage = normalizeLanguage(language);
   const now = Date.now();
+  const cached = minimalDataCacheByLang.get(normalizedLanguage);
 
-  // Return cached data if it's still fresh
-  const cached = minimalDataCacheByLang.get(language);
   if (cached && now - cached.time < CACHE_TTL) {
-    console.debug(`📦 Using cached minimal Tarkov data [${language}]`);
+    console.debug(`📦 Using cached minimal Tarkov data [${normalizedLanguage}]`);
     return cached.data;
   }
 
-  const startTime = Date.now();
-  const query = `
-    {
-      pvpItems: items(gameMode: regular, lang: ${language}) {
-        id
-        name
-        shortName
-        basePrice
-        lastLowPrice
-        avg24hPrice
-        categories {
-          name
-        }
-        link
-        sellFor {
-          vendor {
-            normalizedName
-          }
-          priceRUB
-        }
-        buyFor {
-          priceRUB
-          vendor {
-            normalizedName
-            ... on TraderOffer {
-              minTraderLevel
-              buyLimit
-            }
-          }
-        }
-      }
-      pveItems: items(gameMode: pve, lang: ${language}) {
-        id
-        name
-        shortName
-        basePrice
-        lastLowPrice
-        avg24hPrice
-        categories {
-          name
-        }
-        link
-        sellFor {
-          vendor {
-            normalizedName
-          }
-          priceRUB
-        }
-        buyFor {
-          priceRUB
-          vendor {
-            normalizedName
-            ... on TraderOffer {
-              minTraderLevel
-              buyLimit
-            }
-          }
-        }
-      }
-    }
-  `;
+  const [pvpItems, pveItems] = await Promise.all([
+    fetchMinimalTarkovDataForMode("regular", normalizedLanguage),
+    fetchMinimalTarkovDataForMode("pve", normalizedLanguage),
+  ]);
 
-  try {
-    console.debug("🔄 Fetching minimal Tarkov data");
-    const response = await fetch(GRAPHQL_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({ query }),
-      // Using CACHE_TTL instead of next.revalidate for consistency
-    });
-
-    if (!response.ok) {
-      console.error(
-        `❌ HTTP error! Status: ${response.status} when fetching minimal Tarkov data`
-      );
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-
-    const result: FetchMinimalTarkovGraphQLResponse = await response.json();
-
-    if (!result.data || !result.data.pvpItems || !result.data.pveItems) {
-      console.error("❌ No data in GraphQL response for minimal fetch");
-      throw new Error("No data returned from Tarkov API for minimal fetch");
-    }
-
-    // Only throw on errors if they're critical (not just translation warnings)
-    if (result.errors && result.errors.length > 0) {
-      const hasNonTranslationErrors = result.errors.some(
-        (e) => !e.message.includes("Missing translation for key")
-      );
-
-      if (hasNonTranslationErrors) {
-        console.error("❌ GraphQL errors on minimal fetch:", result.errors);
-        throw new Error(
-          `GraphQL error: ${result.errors.map((e) => e.message).join(", ")}`
-        );
-      } else {
-        console.warn(
-          `⚠️ Translation warnings in minimal fetch (${result.errors.length} items missing translations for language: ${language})`
-        );
-      }
-    }
-
-    const endTime = Date.now();
-    console.debug(`✅ Minimal Tarkov data fetched in ${endTime - startTime}ms`);
-
-    // Update the cache
-    const data = {
-      pvpItems: result.data.pvpItems,
-      pveItems: result.data.pveItems,
-    };
-    minimalDataCacheByLang.set(language, { data, time: now });
-
-    return data;
-  } catch (error) {
-    console.error("❌ Failed to fetch minimal Tarkov data:", error);
-    return { pvpItems: [], pveItems: [] };
-  }
+  const data = { pvpItems, pveItems };
+  minimalDataCacheByLang.set(normalizedLanguage, { data, time: now });
+  return data;
 }

--- a/lib/persisted-selected-items.ts
+++ b/lib/persisted-selected-items.ts
@@ -56,3 +56,13 @@ export function restoreSelectedItemsFromIds(
     return itemsById.get(itemId) ?? null;
   });
 }
+
+export function remapSelectedItemsToCurrentData(
+  selectedItems: Array<SimplifiedItem | null>,
+  items: SimplifiedItem[],
+): Array<SimplifiedItem | null> {
+  return restoreSelectedItemsFromIds(
+    getPersistedSelectedItemIds(selectedItems),
+    items,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint": "eslint . --max-warnings=0",
     "test": "vitest run",
     "test:watch": "vitest",
-    "add-recipe": "bun tools/add-recipe.ts"
+    "add-recipe": "bun tools/add-recipe.ts",
+    "probe:json-api": "node scripts/probe-json-api.mjs",
+    "benchmark:load": "node scripts/benchmark-load.mjs"
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.9",
@@ -102,6 +104,7 @@
     "eslint-config-prettier": "^10.0.1",
     "json5-loader": "^4.0.0",
     "jsdom": "^26.1.0",
+    "playwright": "^1.59.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5",

--- a/scripts/benchmark-load.mjs
+++ b/scripts/benchmark-load.mjs
@@ -1,0 +1,211 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { chromium } from "playwright";
+
+const BASE_URL = process.env.BENCHMARK_BASE_URL ?? "http://127.0.0.1:3100";
+const ROUTES = (process.env.BENCHMARK_ROUTES ?? "/,/base-values")
+  .split(",")
+  .map((route) => route.trim())
+  .filter(Boolean);
+const COLD_RUNS = Number(process.env.BENCHMARK_COLD_RUNS ?? "3");
+const WARM_RUNS = Number(process.env.BENCHMARK_WARM_RUNS ?? "3");
+const SETTLE_DELAY_MS = Number(process.env.BENCHMARK_SETTLE_DELAY_MS ?? "1500");
+const OUTPUT_DIR = join(process.cwd(), "benchmark-results");
+
+function average(values) {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function median(values) {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function summarizeRuns(runs) {
+  return {
+    count: runs.length,
+    avgResponseStartMs: average(runs.map((run) => run.browserTimings.responseStartMs)),
+    medianResponseStartMs: median(
+      runs.map((run) => run.browserTimings.responseStartMs)
+    ),
+    avgDomContentLoadedMs: average(
+      runs.map((run) => run.browserTimings.domContentLoadedMs)
+    ),
+    medianDomContentLoadedMs: median(
+      runs.map((run) => run.browserTimings.domContentLoadedMs)
+    ),
+    avgLoadEventMs: average(runs.map((run) => run.browserTimings.loadEventMs)),
+    medianLoadEventMs: median(runs.map((run) => run.browserTimings.loadEventMs)),
+    avgSettledMs: average(runs.map((run) => run.totalUntilSettledMs)),
+    medianSettledMs: median(runs.map((run) => run.totalUntilSettledMs)),
+    avgRelevantRequestCount: average(
+      runs.map((run) => run.relevantRequests.length)
+    ),
+    avgRelevantRequestDurationMs: average(
+      runs.map((run) =>
+        run.relevantRequests.reduce(
+          (sum, request) => sum + request.durationMs,
+          0
+        )
+      )
+    ),
+  };
+}
+
+function isRelevantDataRequest(url) {
+  return (
+    url.includes("api.tarkov.dev/graphql") ||
+    url.includes("json.tarkov.dev")
+  );
+}
+
+async function measurePageLoad(page, route, mode, iteration) {
+  const requestStartedAt = new Map();
+  const relevantRequests = [];
+
+  const onRequest = (request) => {
+    if (isRelevantDataRequest(request.url())) {
+      requestStartedAt.set(request.url(), Date.now());
+    }
+  };
+
+  const onResponse = (response) => {
+    const url = response.url();
+    const startedAt = requestStartedAt.get(url);
+
+    if (!startedAt || !isRelevantDataRequest(url)) {
+      return;
+    }
+
+    relevantRequests.push({
+      url,
+      durationMs: Date.now() - startedAt,
+      status: response.status(),
+    });
+  };
+
+  page.on("request", onRequest);
+  page.on("response", onResponse);
+
+  const url = new URL(route, BASE_URL).toString();
+  const startedAt = performance.now();
+  const response = await page.goto(url, { waitUntil: "load", timeout: 60000 });
+  await page.waitForTimeout(SETTLE_DELAY_MS);
+  const endedAt = performance.now();
+
+  const browserTimings = await page.evaluate(() => {
+    const entry = performance.getEntriesByType("navigation")[0];
+
+    if (!entry) {
+      return {
+        responseStartMs: 0,
+        domContentLoadedMs: 0,
+        loadEventMs: 0,
+      };
+    }
+
+    return {
+      responseStartMs: entry.responseStart,
+      domContentLoadedMs: entry.domContentLoadedEventEnd,
+      loadEventMs: entry.loadEventEnd,
+    };
+  });
+
+  page.off("request", onRequest);
+  page.off("response", onResponse);
+
+  return {
+    route,
+    mode,
+    iteration,
+    url,
+    status: response?.status() ?? 0,
+    browserTimings,
+    totalUntilSettledMs: endedAt - startedAt,
+    relevantRequests,
+  };
+}
+
+async function runColdRoute(route) {
+  const browser = await chromium.launch({ headless: true });
+  const runs = [];
+
+  for (let iteration = 1; iteration <= COLD_RUNS; iteration += 1) {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    runs.push(await measurePageLoad(page, route, "cold", iteration));
+    await context.close();
+  }
+
+  await browser.close();
+  return runs;
+}
+
+async function runWarmRoute(route) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const runs = [];
+
+  for (let iteration = 1; iteration <= WARM_RUNS; iteration += 1) {
+    runs.push(await measurePageLoad(page, route, "warm", iteration));
+  }
+
+  await context.close();
+  await browser.close();
+  return runs;
+}
+
+async function main() {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  const results = [];
+  for (const route of ROUTES) {
+    console.error(`Benchmarking ${route}...`);
+    const coldRuns = await runColdRoute(route);
+    const warmRuns = await runWarmRoute(route);
+
+    results.push({
+      route,
+      coldRuns,
+      warmRuns,
+      summary: {
+        cold: summarizeRuns(coldRuns),
+        warm: summarizeRuns(warmRuns),
+      },
+    });
+  }
+
+  const payload = {
+    capturedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    coldRuns: COLD_RUNS,
+    warmRuns: WARM_RUNS,
+    settleDelayMs: SETTLE_DELAY_MS,
+    results,
+  };
+
+  const fileName = `benchmark-${new Date()
+    .toISOString()
+    .replace(/[:.]/g, "-")}.json`;
+  const outputPath = join(OUTPUT_DIR, fileName);
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`);
+
+  console.log(JSON.stringify({ outputPath, payload }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/probe-json-api.mjs
+++ b/scripts/probe-json-api.mjs
@@ -1,0 +1,282 @@
+const BASE_URL = "https://json.tarkov.dev";
+const PRIMARY_LANG = process.argv[2] ?? "fr";
+const FALLBACK_LANG = "en";
+
+async function fetchJson(path) {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${path} -> ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+function translateValue(key, primary, fallback) {
+  if (!key) {
+    return undefined;
+  }
+
+  return primary[key] ?? fallback[key] ?? key;
+}
+
+function pickFirstKey(record) {
+  const firstKey = Object.keys(record)[0];
+  if (!firstKey) {
+    throw new Error("Expected non-empty record");
+  }
+
+  return firstKey;
+}
+
+function summarizeTranslationEntries(translationMap, count = 8) {
+  return Object.entries(translationMap)
+    .slice(0, count)
+    .map(([key, value]) => ({ key, value }));
+}
+
+function toCurrentShapeSample({
+  item,
+  itemCategories,
+  traders,
+  primaryTranslations,
+  fallbackTranslations,
+}) {
+  return {
+    id: item.id,
+    name: translateValue(item.name, primaryTranslations, fallbackTranslations),
+    shortName: translateValue(
+      item.shortName,
+      primaryTranslations,
+      fallbackTranslations
+    ),
+    englishName: translateValue(
+      item.name,
+      fallbackTranslations,
+      fallbackTranslations
+    ),
+    englishShortName: translateValue(
+      item.shortName,
+      fallbackTranslations,
+      fallbackTranslations
+    ),
+    basePrice: item.basePrice,
+    lastLowPrice: item.lastLowPrice,
+    avg24hPrice: item.avg24hPrice,
+    updated: item.updated,
+    width: item.width,
+    height: item.height,
+    iconLink: item.iconLink,
+    link: item.link,
+    categories: item.categories,
+    categories_display: item.categories.map((categoryId) => ({
+      id: categoryId,
+      name:
+        translateValue(
+          itemCategories[categoryId]?.name,
+          primaryTranslations,
+          fallbackTranslations
+        ) ?? categoryId,
+    })),
+    categories_display_en: item.categories.map((categoryId) => ({
+      id: categoryId,
+      name:
+        translateValue(
+          itemCategories[categoryId]?.name,
+          fallbackTranslations,
+          fallbackTranslations
+        ) ?? categoryId,
+    })),
+    buyFor: (item.buyFromTrader ?? []).map((offer) => ({
+      priceRUB: offer.priceRUB,
+      vendor: {
+        normalizedName: traders[offer.trader]?.normalizedName ?? offer.trader,
+        minTraderLevel: offer.minTraderLevel,
+      },
+    })),
+    sellFor: (item.sellToTrader ?? []).map((offer) => ({
+      priceRUB: offer.priceRUB,
+      vendor: {
+        normalizedName: traders[offer.trader]?.normalizedName ?? offer.trader,
+      },
+    })),
+  };
+}
+
+async function main() {
+  const [
+    endpointIndex,
+    regularItems,
+    pveItems,
+    englishTranslations,
+    primaryTranslations,
+    traders,
+    barters,
+    maps,
+    tasks,
+    hideout,
+    crafts,
+  ] = await Promise.all([
+    fetchJson("/endpoints"),
+    fetchJson("/regular/items"),
+    fetchJson("/pve/items"),
+    fetchJson(`/regular/items_${FALLBACK_LANG}`),
+    fetchJson(`/regular/items_${PRIMARY_LANG}`),
+    fetchJson("/regular/traders"),
+    fetchJson("/regular/barters"),
+    fetchJson("/regular/maps"),
+    fetchJson("/regular/tasks"),
+    fetchJson("/regular/hideout"),
+    fetchJson("/regular/crafts"),
+  ]);
+
+  const firstRegularItemId = pickFirstKey(regularItems.data.items);
+  const firstRegularItem = regularItems.data.items[firstRegularItemId];
+  const traderItem =
+    Object.values(regularItems.data.items).find(
+      (item) =>
+        Array.isArray(item.buyFromTrader) &&
+        item.buyFromTrader.length > 0 &&
+        Array.isArray(item.sellToTrader) &&
+        item.sellToTrader.length > 0
+    ) ?? firstRegularItem;
+  const itemIdsWithBuyFromTrader = new Set(
+    Object.values(regularItems.data.items)
+      .filter((item) => (item.buyFromTrader ?? []).length > 0)
+      .map((item) => item.id)
+  );
+  const barterItemIds = new Set(
+    barters.data
+      .map((offer) => offer.offeredItem?.item)
+      .filter(Boolean)
+  );
+  const bartersWithoutDirectBuy = [...barterItemIds].filter(
+    (itemId) => !itemIdsWithBuyFromTrader.has(itemId)
+  );
+
+  const summary = {
+    probedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    requestedPrimaryLanguage: PRIMARY_LANG,
+    endpointIndex: endpointIndex.data,
+    repoMapping: {
+      requiredNow: [
+        "/regular/items",
+        "/pve/items",
+        "/regular/items_en",
+        "/pve/items_en",
+        `/regular/items_${PRIMARY_LANG}`,
+        `/pve/items_${PRIMARY_LANG}`,
+      ],
+      optionalNow: ["/lang"],
+      notUsedByCurrentRepo: [
+        "/regular/maps",
+        "/regular/tasks",
+        "/regular/hideout",
+        "/regular/crafts",
+        "/regular/barters",
+        "/regular/traders",
+        "/status",
+        "/regular/prices/{itemId}",
+      ],
+    },
+    items: {
+      regularItemCount: Object.keys(regularItems.data.items).length,
+      pveItemCount: Object.keys(pveItems.data.items).length,
+      itemCategoryCount: Object.keys(regularItems.data.itemCategories).length,
+      handbookCategoryCount: Object.keys(regularItems.data.handbookCategories)
+        .length,
+      topLevelSections: Object.keys(regularItems.data),
+      translationPathCount: regularItems.translations?.length ?? 0,
+      translationPathSamples: (regularItems.translations ?? []).slice(0, 8),
+      firstItemShape: {
+        itemId: firstRegularItemId,
+        keys: Object.keys(firstRegularItem),
+        categoryIds: firstRegularItem.categories,
+        categoryLookupSample:
+          regularItems.data.itemCategories[firstRegularItem.categories[0] ?? ""],
+      },
+      traderItemShape: {
+        itemId: traderItem.id,
+        rawName: traderItem.name,
+        rawShortName: traderItem.shortName,
+        buyFromTraderSample: traderItem.buyFromTrader?.[0] ?? null,
+        sellToTraderSample: traderItem.sellToTrader?.[0] ?? null,
+        adaptedCurrentShapeSample: toCurrentShapeSample({
+          item: traderItem,
+          itemCategories: regularItems.data.itemCategories,
+          traders: traders.data,
+          primaryTranslations: primaryTranslations.data,
+          fallbackTranslations: englishTranslations.data,
+        }),
+      },
+      parityGaps: {
+        directTraderOffersExposeBuyLimit: Object.values(
+          regularItems.data.items
+        ).some((item) =>
+          (item.buyFromTrader ?? []).some((offer) =>
+            Object.prototype.hasOwnProperty.call(offer, "buyLimit")
+          )
+        ),
+        barterOfferCount: barters.data.length,
+        barterItemCount: barterItemIds.size,
+        barterItemsWithoutDirectBuyFromTraderCount:
+          bartersWithoutDirectBuy.length,
+        barterItemsWithoutDirectBuySample: bartersWithoutDirectBuy
+          .slice(0, 8)
+          .map((itemId) => ({
+            itemId,
+            rawName: regularItems.data.items[itemId]?.name ?? null,
+          })),
+      },
+    },
+    translations: {
+      englishEntrySamples: summarizeTranslationEntries(englishTranslations.data),
+      primaryEntrySamples: summarizeTranslationEntries(primaryTranslations.data),
+      itemBaseNameIsTranslationKey:
+        firstRegularItem.name !==
+        translateValue(
+          firstRegularItem.name,
+          englishTranslations.data,
+          englishTranslations.data
+        ),
+    },
+    adjacentEndpointShapes: {
+      maps: {
+        topLevelSections: Object.keys(maps.data),
+        translationPathCount: maps.translations?.length ?? 0,
+      },
+      tasks: {
+        topLevelSections: Object.keys(tasks.data),
+        translationPathCount: tasks.translations?.length ?? 0,
+      },
+      hideout: {
+        recordCount: Object.keys(hideout.data).length,
+        translationPathCount: hideout.translations?.length ?? 0,
+      },
+      crafts: {
+        count: crafts.data.length,
+        firstEntryKeys: Object.keys(crafts.data[0] ?? {}),
+      },
+      barters: {
+        count: barters.data.length,
+        firstEntryKeys: Object.keys(barters.data[0] ?? {}),
+      },
+      traders: {
+        count: Object.keys(traders.data).length,
+        firstTraderId: pickFirstKey(traders.data),
+        firstTraderKeys: Object.keys(traders.data[pickFirstKey(traders.data)]),
+        translationPathCount: traders.translations?.length ?? 0,
+      },
+    },
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/hooks/use-items-data.test.tsx
+++ b/tests/hooks/use-items-data.test.tsx
@@ -20,41 +20,31 @@ function Harness({ isPVE = false }: { isPVE?: boolean }) {
   return <pre data-testid="out">{JSON.stringify(data)}</pre>;
 }
 
-describe('useItemsData dual-fetch + merge', () => {
+describe('useItemsData single-fetch localized mapping', () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
     localStorage.clear();
   });
 
-  test('fetches en + localized and merges correctly (name/shortName localized, englishName retained)', async () => {
-    // Arrange english and german fixtures
-    const enItems: SimplifiedItem[] = [
-      {
-        id: 'itm1',
-        name: 'Antique Vase',
-        shortName: 'Vase',
-        basePrice: 67800,
-        categories: ['Barter item'],
-        categories_display: [{ name: 'Barter item' }],
-      },
-    ];
-
+  test('fetches localized items once and uses english fallback fields from the payload', async () => {
     const deItems: SimplifiedItem[] = [
       {
         id: 'itm1',
         name: 'Antike Vase',
         shortName: 'Vase',
+        englishName: 'Antique Vase',
+        englishShortName: 'Vase',
         basePrice: 67800,
-        categories: ['Barter item (de)'],
+        categories: ['barter-item'],
         categories_display: [{ name: 'Tauschgegenstand' }],
+        categories_display_en: [{ name: 'Barter item' }],
         iconLink: 'de-icon.png',
       },
     ];
 
     (fetchTarkovData as unknown as any).mockImplementation((mode: 'pve' | 'regular', lang: string) => {
-      const items = lang === 'en' ? enItems : deItems;
-      return Promise.resolve({ items, meta: { totalItems: items.length, validItems: items.length, processTime: 1, categories: 1, mode: mode === 'pve' ? 'pve' : 'pvp' } });
+      return Promise.resolve({ items: deItems, meta: { totalItems: deItems.length, validItems: deItems.length, processTime: 1, categories: 1, mode: mode === 'pve' ? 'pve' : 'pvp' } });
     });
 
     // Force language to de via localStorage so LanguageProvider initializes with it
@@ -78,16 +68,15 @@ describe('useItemsData dual-fetch + merge', () => {
       // English fields retained for filtering
       expect(item.englishName).toBe('Antique Vase');
       expect(item.englishShortName).toBe('Vase');
-      // Categories used for filtering are from English
-      expect(item.categories).toEqual(['Barter item']);
+      // Stable category ids stay intact
+      expect(item.categories).toEqual(['barter-item']);
       // Display categories may be localized
       expect(item.categories_display?.[0].name).toBe('Tauschgegenstand');
+      expect(item.categories_display_en?.[0].name).toBe('Barter item');
     });
 
-    // Called twice: en + de
-    expect(fetchTarkovData).toHaveBeenCalledTimes(2);
-    expect(fetchTarkovData).toHaveBeenNthCalledWith(1, 'regular', 'en');
-    expect(fetchTarkovData).toHaveBeenNthCalledWith(2, 'regular', 'de');
+    expect(fetchTarkovData).toHaveBeenCalledTimes(1);
+    expect(fetchTarkovData).toHaveBeenCalledWith('regular', 'de');
   });
 
   test('when language is en, only one fetch occurs and english is used for display', async () => {

--- a/tests/hooks/use-tarkov-api.test.ts
+++ b/tests/hooks/use-tarkov-api.test.ts
@@ -1,16 +1,168 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   fetchCombinedTarkovData,
   fetchMinimalTarkovData,
   fetchTarkovData,
   resetTarkovApiCachesForTests,
-} from '@/hooks/use-tarkov-api';
+} from "@/hooks/use-tarkov-api";
 
-const emptyCombinedResponse = {
-  data: { pvpItems: [], pveItems: [] },
+const regularItemsResponse = {
+  data: {
+    items: {
+      "item-regular": {
+        id: "item-regular",
+        name: "item-regular Name",
+        shortName: "item-regular ShortName",
+        normalizedName: "item-regular",
+        description: "item-regular Description",
+        updated: "2026-04-08T16:48:01.000Z",
+        width: 1,
+        height: 2,
+        lastOfferCount: 10,
+        iconLink: "https://assets.tarkov.dev/item-regular-icon.webp",
+        link: "https://tarkov.dev/item/item-regular",
+        basePrice: 100,
+        lastLowPrice: 80,
+        avg24hPrice: 120,
+        categories: ["cat-weapon"],
+        buyFromTrader: [
+          {
+            trader: "5a7c2eca46aef81a7ca2145d",
+            price: 100,
+            priceRUB: 100,
+            currency: "RUB",
+            currencyItem: "roubles",
+            minTraderLevel: 2,
+            taskUnlock: null,
+          },
+        ],
+        sellToTrader: [
+          {
+            trader: "54cb50c76803fa8b248b4571",
+            price: 40,
+            priceRUB: 40,
+            currency: "RUB",
+            currencyItem: "roubles",
+          },
+        ],
+      },
+    },
+    itemCategories: {
+      "cat-weapon": {
+        id: "cat-weapon",
+        name: "cat-weapon Name",
+        normalizedName: "weapon",
+        parent: null,
+        children: [],
+      },
+    },
+  },
 };
 
-describe('use-tarkov-api GraphQL fetchers', () => {
+const pveItemsResponse = {
+  data: {
+    items: {
+      "item-pve": {
+        id: "item-pve",
+        name: "item-pve Name",
+        shortName: "item-pve ShortName",
+        normalizedName: "item-pve",
+        description: "item-pve Description",
+        updated: "2026-04-08T16:48:01.000Z",
+        width: 1,
+        height: 1,
+        lastOfferCount: 5,
+        iconLink: "https://assets.tarkov.dev/item-pve-icon.webp",
+        link: "https://tarkov.dev/item/item-pve",
+        basePrice: 200,
+        lastLowPrice: 150,
+        avg24hPrice: 260,
+        categories: ["cat-key"],
+        buyFromTrader: [
+          {
+            trader: "54cb57776803fa99248b456e",
+            price: 200,
+            priceRUB: 200,
+            currency: "RUB",
+            currencyItem: "roubles",
+            minTraderLevel: 1,
+            taskUnlock: null,
+          },
+        ],
+        sellToTrader: [
+          {
+            trader: "579dc571d53a0658a154fbec",
+            price: 100,
+            priceRUB: 100,
+            currency: "RUB",
+            currencyItem: "roubles",
+          },
+        ],
+      },
+    },
+    itemCategories: {
+      "cat-key": {
+        id: "cat-key",
+        name: "cat-key Name",
+        normalizedName: "key",
+        parent: null,
+        children: [],
+      },
+    },
+  },
+};
+
+const englishTranslations = {
+  data: {
+    "item-regular Name": "Regular Rifle",
+    "item-regular ShortName": "RR",
+    "cat-weapon Name": "Weapon",
+    "item-pve Name": "PVE Key",
+    "item-pve ShortName": "PK",
+    "cat-key Name": "Key",
+  },
+};
+
+const germanTranslations = {
+  data: {
+    "item-regular Name": "Regulares Gewehr",
+    "item-regular ShortName": "RG",
+    "cat-weapon Name": "Waffe",
+    "item-pve Name": "PVE Schlussel",
+    "item-pve ShortName": "PS",
+    "cat-key Name": "Schlussel",
+  },
+};
+
+function createMockResponse(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as Response;
+}
+
+function installJsonApiMock() {
+  return vi.spyOn(global, "fetch" as never).mockImplementation((input) => {
+    const url = String(input);
+
+    if (url.endsWith("/regular/items")) {
+      return Promise.resolve(createMockResponse(regularItemsResponse));
+    }
+    if (url.endsWith("/pve/items")) {
+      return Promise.resolve(createMockResponse(pveItemsResponse));
+    }
+    if (url.endsWith("/regular/items_en") || url.endsWith("/pve/items_en")) {
+      return Promise.resolve(createMockResponse(englishTranslations));
+    }
+    if (url.endsWith("/regular/items_de") || url.endsWith("/pve/items_de")) {
+      return Promise.resolve(createMockResponse(germanTranslations));
+    }
+
+    return Promise.reject(new Error(`Unexpected URL: ${url}`));
+  });
+}
+
+describe("use-tarkov-api JSON fetchers", () => {
   beforeEach(() => {
     resetTarkovApiCachesForTests();
     vi.restoreAllMocks();
@@ -20,83 +172,109 @@ describe('use-tarkov-api GraphQL fetchers', () => {
     vi.restoreAllMocks();
   });
 
-  test('fetchCombinedTarkovData includes lang in query and caches per language', async () => {
-    const fetchMock = vi
-      .spyOn(global, 'fetch' as any)
-      .mockResolvedValue({ ok: true, json: async () => emptyCombinedResponse } as any);
+  test("fetchCombinedTarkovData calls JSON endpoints per language and caches results", async () => {
+    const fetchMock = installJsonApiMock();
 
-    await fetchCombinedTarkovData('de');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const init1 = fetchMock.mock.calls[0][1] as any;
-    const body1 = JSON.parse(init1.body as string);
-    expect(body1.query).toContain('lang: de');
+    await fetchCombinedTarkovData("de");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls.map((call) => String(call[0])).sort()).toEqual([
+      "https://json.tarkov.dev/regular/items",
+      "https://json.tarkov.dev/regular/items_en",
+      "https://json.tarkov.dev/regular/items_de",
+      "https://json.tarkov.dev/pve/items",
+    ].sort());
 
-    // Same language -> cached, no extra fetch
-    await fetchCombinedTarkovData('de');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await fetchCombinedTarkovData("de");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
 
-    // Different language -> new network call
-    await fetchCombinedTarkovData('en');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const init2 = fetchMock.mock.calls[1][1] as any;
-    const body2 = JSON.parse(init2.body as string);
-    expect(body2.query).toContain('lang: en');
+    await fetchCombinedTarkovData("en");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
-  test('fetchTarkovData returns per-mode items and correct meta.mode', async () => {
-    const response = {
-      data: {
-        pvpItems: [
-          {
-            id: '1', name: 'Item A', shortName: 'A', basePrice: 100, lastLowPrice: null,
-            updated: new Date().toISOString(), width: 1, height: 1, lastOfferCount: 10,
-            avg24hPrice: null, iconLink: '', categories: [{ name: 'Weapon' }], buyFor: []
-          },
-        ],
-        pveItems: [
-          {
-            id: '2', name: 'Item B', shortName: 'B', basePrice: 200, lastLowPrice: null,
-            updated: new Date().toISOString(), width: 1, height: 1, lastOfferCount: 10,
-            avg24hPrice: null, iconLink: '', categories: [{ name: 'Key' }], buyFor: []
-          },
-        ],
-      },
-    };
+  test("fetchTarkovData returns localized items with stable category ids and trader names", async () => {
+    installJsonApiMock();
 
-    const fetchMock = vi
-      .spyOn(global, 'fetch' as any)
-      .mockResolvedValue({ ok: true, json: async () => response } as any);
-
-    const pvp = await fetchTarkovData('regular', 'en');
+    const pvp = await fetchTarkovData("regular", "de");
+    expect(pvp.meta.mode).toBe("pvp");
     expect(pvp.items).toHaveLength(1);
-    expect(pvp.meta.mode).toBe('pvp');
+    expect(pvp.items[0]).toMatchObject({
+      id: "item-regular",
+      name: "Regulares Gewehr",
+      shortName: "RG",
+      categories: ["cat-weapon"],
+      categories_display: [{ id: "cat-weapon", name: "Waffe" }],
+      categories_display_en: [{ id: "cat-weapon", name: "Weapon" }],
+      buyFor: [
+        {
+          priceRUB: 100,
+          vendor: {
+            normalizedName: "mechanic",
+            minTraderLevel: 2,
+          },
+        },
+      ],
+    });
 
-    const pve = await fetchTarkovData('pve', 'en');
+    const pve = await fetchTarkovData("pve", "de");
+    expect(pve.meta.mode).toBe("pve");
     expect(pve.items).toHaveLength(1);
-    expect(pve.meta.mode).toBe('pve');
-
-    // only two fetches: both calls shared the same combined fetch via cache within single run? depends on cache; allow >=1
-    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(pve.items[0]).toMatchObject({
+      id: "item-pve",
+      name: "PVE Schlussel",
+      categories: ["cat-key"],
+      categories_display: [{ id: "cat-key", name: "Schlussel" }],
+      categories_display_en: [{ id: "cat-key", name: "Key" }],
+      buyFor: [
+        {
+          priceRUB: 200,
+          vendor: {
+            normalizedName: "therapist",
+            minTraderLevel: 1,
+          },
+        },
+      ],
+    });
   });
 
-  test('fetchMinimalTarkovData includes lang and caches per language', async () => {
-    const minimalResponse = {
-      data: { pvpItems: [], pveItems: [] },
-    };
-    const fetchMock = vi
-      .spyOn(global, 'fetch' as any)
-      .mockResolvedValue({ ok: true, json: async () => minimalResponse } as any);
+  test("fetchMinimalTarkovData returns localized categories and leaves missing buyLimit undefined", async () => {
+    installJsonApiMock();
 
-    await fetchMinimalTarkovData('fr');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const init3 = fetchMock.mock.calls[0][1] as any;
-    const body1 = JSON.parse(init3.body as string);
-    expect(body1.query).toContain('lang: fr');
+    const minimal = await fetchMinimalTarkovData("de");
 
-    await fetchMinimalTarkovData('fr');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(minimal.pvpItems[0]).toMatchObject({
+      id: "item-regular",
+      name: "Regulares Gewehr",
+      shortName: "RG",
+      categories: [{ name: "Waffe" }],
+      sellFor: [
+        {
+          priceRUB: 40,
+          vendor: {
+            normalizedName: "prapor",
+          },
+        },
+      ],
+      buyFor: [
+        {
+          priceRUB: 100,
+          vendor: {
+            normalizedName: "mechanic",
+            minTraderLevel: 2,
+          },
+        },
+      ],
+    });
+    expect(minimal.pvpItems[0].buyFor[0].vendor.buyLimit).toBeUndefined();
+    expect(minimal.pveItems[0].categories).toEqual([{ name: "Schlussel" }]);
+  });
 
-    await fetchMinimalTarkovData('en');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+  test("fetchMinimalTarkovData returns empty arrays on request failure", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(global, "fetch" as never).mockRejectedValue(new Error("boom"));
+
+    const minimal = await fetchMinimalTarkovData("en");
+
+    expect(minimal).toEqual({ pvpItems: [], pveItems: [] });
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/tests/lib/persisted-selected-items.test.ts
+++ b/tests/lib/persisted-selected-items.test.ts
@@ -1,6 +1,7 @@
 import {
   getPersistedSelectedItemIds,
   parsePersistedSelectedItemIds,
+  remapSelectedItemsToCurrentData,
   restoreSelectedItemsFromIds,
   SELECTED_ITEM_SLOT_COUNT,
 } from "@/lib/persisted-selected-items";
@@ -53,5 +54,23 @@ describe("persisted selected items", () => {
         items,
       ),
     ).toEqual([items[1], null, null, items[0], null]);
+  });
+
+  it("remaps persisted selections onto the latest item objects", () => {
+    const englishSelectedItems = [
+      createItem("item-1", "Antique Vase"),
+      null,
+      createItem("item-3", "Roler"),
+      null,
+      null,
+    ];
+    const localizedItems = [
+      createItem("item-1", "Antike Vase"),
+      createItem("item-3", "Roler (DE)"),
+    ];
+
+    expect(
+      remapSelectedItemsToCurrentData(englishSelectedItems, localizedItems),
+    ).toEqual([localizedItems[0], null, localizedItems[1], null, null]);
   });
 });

--- a/types/SimplifiedItem.ts
+++ b/types/SimplifiedItem.ts
@@ -3,6 +3,7 @@
 export interface TraderVendorInfo {
   normalizedName: string;
   minTraderLevel?: number;
+  buyLimit?: number;
 }
 
 export interface TraderBuyOffer {


### PR DESCRIPTION
## Summary
- switch item and base-values loading from the GraphQL endpoint to `json.tarkov.dev`
- preserve the current app-facing item shapes with a JSON adapter and focused test coverage
- add a client-side benchmark harness plus before/after benchmark artifacts for the migration and perf follow-up

## Details
- replaces the item fetchers in `hooks/use-tarkov-api.ts` with JSON endpoint mapping, translation handling, and client-side caching
- updates `useItemsData` to avoid the extra english-plus-localized fetch path
- updates `/base-values` to load only the active mode initially and fetch the other mode on demand
- documents the endpoint research and benchmark results in `docs/tarkov-json-api-research.md`

## Verification
- `bun run build`
- `bun run lint`
- `bunx vitest run tests/hooks/use-tarkov-api.test.ts tests/hooks/use-items-data.test.tsx`

## Notes
- full `bun run test` still has the existing `tests/components/info-dashboard-alerts.test.ts` failures unrelated to this change

## Benchmarks
Production benchmark artifacts:
- `benchmark-results/benchmark-graphql-baseline.json`
- `benchmark-results/benchmark-json-final.json`
- `benchmark-results/benchmark-json-perf-pass2.json`

Key averages from the benchmark harness:
- `/` cold settled: `2291ms` GraphQL baseline -> `2729ms` first JSON pass -> `2237ms` perf pass 2
- `/` warm settled: `1940ms` GraphQL baseline -> `2263ms` first JSON pass -> `1952ms` perf pass 2
- `/base-values` cold settled: `2062ms` GraphQL baseline -> `2406ms` first JSON pass -> `2078ms` perf pass 2
- `/base-values` warm settled: `1866ms` GraphQL baseline -> `2204ms` first JSON pass -> `1993ms` perf pass 2